### PR TITLE
middlewares which wrap the EventWriter should still be Hijackers

### DIFF
--- a/gzip_middleware.go
+++ b/gzip_middleware.go
@@ -5,7 +5,9 @@ package httputil2
 //       all written and then flush ?
 
 import (
+	"bufio"
 	"compress/gzip"
+	"net"
 	"net/http"
 	"sync"
 )
@@ -132,6 +134,11 @@ func (self *gzipResponseWriter) CloseNotify() <-chan bool {
 	return ch
 }
 
+func (self *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return (self.w.(http.Hijacker)).Hijack()
+}
+
 var _ http.ResponseWriter = new(gzipResponseWriter)
 var _ http.Flusher = new(gzipResponseWriter)
 var _ http.CloseNotifier = new(gzipResponseWriter)
+var _ http.Hijacker = new(gzipResponseWriter)

--- a/log_middleware.go
+++ b/log_middleware.go
@@ -3,6 +3,8 @@ package httputil2
 // TODO: implement the http.Hijacker interfaces
 
 import (
+	"bufio"
+	"net"
 	"net/http"
 	"time"
 )
@@ -62,6 +64,11 @@ func (self *logResponseWriter) CloseNotify() <-chan bool {
 	return (self.ResponseWriter.(http.CloseNotifier)).CloseNotify()
 }
 
+func (self *logResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return (self.ResponseWriter.(http.Hijacker)).Hijack()
+}
+
 var _ http.ResponseWriter = new(logResponseWriter)
 var _ http.Flusher = new(logResponseWriter)
 var _ http.CloseNotifier = new(logResponseWriter)
+var _ http.Hijacker = new(logResponseWriter)

--- a/recovery_middleware.go
+++ b/recovery_middleware.go
@@ -3,7 +3,9 @@ package httputil2
 // TODO: implement the http.Flusher, http.CloseNotifier and http.Hijacker interfaces
 
 import (
+	"bufio"
 	"log"
+	"net"
 	"net/http"
 )
 
@@ -74,6 +76,11 @@ func (self *recoverResponseWriter) CloseNotify() <-chan bool {
 	return (self.ResponseWriter.(http.CloseNotifier)).CloseNotify()
 }
 
+func (self *recoverResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return (self.ResponseWriter.(http.Hijacker)).Hijack()
+}
+
+var _ http.Hijacker = new(recoverResponseWriter)
 var _ http.ResponseWriter = new(recoverResponseWriter)
 var _ http.Flusher = new(recoverResponseWriter)
 var _ http.CloseNotifier = new(recoverResponseWriter)

--- a/tracking_listener_test.go
+++ b/tracking_listener_test.go
@@ -1,4 +1,4 @@
-package httputil2_test
+package httputil2
 
 import (
 	"net"
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-
-	"github.com/zimbatm/httputil2"
 )
 
 func ExampleNewTrackingListener() {
@@ -28,7 +26,7 @@ func ExampleNewTrackingListener() {
 		panic(err)
 	}
 	// And track them
-	l = httputil2.NewTrackingListener(l, done)
+	l = NewTrackingListener(l, done)
 
 	// Setup signal handling
 	c := make(chan os.Signal)


### PR DESCRIPTION
### Why?

So you can use middleware and upgrade to WebSocket too. 

### How?

- Implemented `http.Hijack` on middlewares which wrap the basic `EventWriter`
- Also fixed a broken test

CC @zimbatm 